### PR TITLE
Use tilde for cldrjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,13 +5,12 @@
   "requires": true,
   "dependencies": {
     "@dojo/framework": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-3.0.1.tgz",
-      "integrity": "sha512-Yta6DPRjIH+JebCY6t7yR7PaxnGOaGKkhmpSj7R9UIzb+H33OX5pQMSacCnPkVAD+/bNvdVm0A1238QVI9RiRQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-4.0.0.tgz",
+      "integrity": "sha512-0yNtfIQVBZiI6Ipdsn9cOTsnwfj0NUflHIRqAgbhKv3vCn7rbKiTephJ271SvXn3+6DlXReDWSLJ5LvkeoAvoQ==",
       "requires": {
         "@types/cldrjs": "0.4.20",
         "@types/globalize": "0.0.34",
-        "@types/web-animations-js": "2.2.5",
         "@webcomponents/webcomponentsjs": "1.1.0",
         "cldrjs": "0.4.8",
         "css-select-umd": "1.3.0-rc0",
@@ -31,9 +30,9 @@
       }
     },
     "@dojo/widgets": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@dojo/widgets/-/widgets-3.0.0.tgz",
-      "integrity": "sha512-MVL/qHhcdnXBMNezfiMOgpUf1wO15hXfjntRA1OI/q/ns9evgpDOXzTpRKhOGytoA/wOfq2ITLOyNqN/mWF8xg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@dojo/widgets/-/widgets-4.0.0.tgz",
+      "integrity": "sha512-nvWboAkZVB47PldzzJuTtxRWC6QhAZaSiNEcE0y5MELGaUbinaPyTyu8eMB7v/LlVsmEqPStfEdDcJM3z6KqwQ==",
       "requires": {
         "tslib": "~1.8.1"
       }
@@ -50,11 +49,6 @@
       "requires": {
         "@types/cldrjs": "*"
       }
-    },
-    "@types/web-animations-js": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@types/web-animations-js/-/web-animations-js-2.2.5.tgz",
-      "integrity": "sha512-3kjO6yvLt1e673wtcKEz0lgLKqPkBiuwxQj0DQ1jj+48HB03emIlTQYcqKAvB9UwOXq09QrWy/Dm6ZU8xMZVTw=="
     },
     "@webcomponents/webcomponentsjs": {
       "version": "1.1.0",
@@ -84,9 +78,9 @@
       }
     },
     "css-what": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
-      "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.2.tgz",
+      "integrity": "sha512-wan8dMWQ0GUeF7DGEPVjhHemVW/vy6xUYmFzRY8RYqgA0JtXC9rJmbScBjqSu6dg9q0lwPQy6ZAmJVr3PPTvqQ=="
     },
     "d": {
       "version": "1.0.0",
@@ -112,15 +106,15 @@
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
           "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
         }
       }
     },
     "domelementtype": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.2.1.tgz",
+      "integrity": "sha512-SQVCLFS2E7G5CRCMdn6K9bIhRj1bS6QBWZfF0TUPh4V/BbqrQ619IdSS3/izn0FZ+9l+uODzaZjb08fjOfablA=="
     },
     "domutils": {
       "version": "1.5.1",
@@ -132,9 +126,9 @@
       }
     },
     "entities": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
     "es5-ext": {
       "version": "0.10.46",
@@ -205,9 +199,9 @@
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "nth-check": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
-      "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
       "requires": {
         "boolbase": "~1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@dojo/framework": "^4.0.0",
     "@dojo/widgets": "^4.0.0",
-    "cldrjs": "0.4.6",
+    "cldrjs": "~0.4.6",
     "tslib": "~1.8.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes dependency for codesandbox. Has to be tilde as globalize which brings in cldrjs is on tilde.