### PR TITLE
use wildcard includes so tsc includes .tsx & .ts

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,7 @@
 		"types": []
 	},
 	"include": [
-		"./src/**/*.ts",
-		"./tests/**/*.ts"
+		"./src/**/*",
+		"./tests/**/*"
 	]
 }


### PR DESCRIPTION
Uses wildcarding in tsconfig.json `includes` section so `tsc` will compile all recognized types (.ts, .tsx, .d.ts, etc...)

Resolves #13